### PR TITLE
Expose the selected hotbar slot in inventory manager peripheral

### DIFF
--- a/src/main/java/de/srendi/advancedperipherals/common/addons/computercraft/peripheral/InventoryManagerPeripheral.java
+++ b/src/main/java/de/srendi/advancedperipherals/common/addons/computercraft/peripheral/InventoryManagerPeripheral.java
@@ -189,7 +189,15 @@ public class InventoryManagerPeripheral extends BasePeripheral<BlockEntityPeriph
 
     @LuaFunction(mainThread = true)
     public final Map<String, Object> getItemInHand() throws LuaException {
-        return LuaConverter.itemStackToObject(getOwnerPlayer().getMainHandItem().copy());
+        return LuaConverter.stackToObjectWithSlot(
+                getOwnerPlayer().getMainHandItem().copy(),
+                getOwnerPlayer().getInventory().selected
+        );
+    }
+
+    @LuaFunction(mainThread = true)
+    public final int getSelectedSlot() throws LuaException {
+        return getOwnerPlayer().getInventory().selected;
     }
 
     @LuaFunction(mainThread = true)


### PR DESCRIPTION
**PLEASE READ THE [GUIDELINES](https://github.com/IntelligenceModding/AdvancedPeripherals/blob/dev/1.21.1/CONTRIBUTING.md) BEFORE MAKING A CONTRIBUTION**


* **Please check if the PR fulfills these requirements**
- [x] The commit message are well described
- [ ] Docs have been added / updated (for features or maybe bugs which were noted). If not, please update the needed documentation [here](https://github.com/IntelligenceModding/Advanced-Peripherals-Documentation/pulls). Feel free to remove this check if you don't need it
- [x] All changes have fully been tested

* **What kind of change does this PR introduce?** (Bug fix, feature, ...)
This PR adds two api changes to get the selected hotbar slot from the inventory manager

* **What is the current behavior?** (You can also link to an open issue here)
Not possible to retrive the real selected slot, you can only iterate over all 9 slots and find a matching item to the one returned by `getItemInHand` which will break when one has two matching stacks in the hotbar

* **What is the new behavior (if this is a feature change)?**
- add slot to the `getItemInHand` method
- add `getSelectedSlot` method

* **Does this PR introduce a breaking change?** (What changes might users need to make in their scripts due to this PR?)
No
