### PR TITLE
Add getCrafters() to RS Bridge

### DIFF
--- a/src/main/java/de/srendi/advancedperipherals/common/addons/computercraft/peripheral/RSBridgePeripheral.java
+++ b/src/main/java/de/srendi/advancedperipherals/common/addons/computercraft/peripheral/RSBridgePeripheral.java
@@ -13,6 +13,7 @@ import com.refinedmods.refinedstorage.mekanism.ChemicalResource;
 import com.refinedmods.refinedstorage.neoforge.support.resource.VariantUtil;
 import dan200.computercraft.api.lua.IArguments;
 import dan200.computercraft.api.lua.LuaException;
+import dan200.computercraft.api.lua.LuaFunction;
 import dan200.computercraft.api.lua.MethodResult;
 import dan200.computercraft.api.peripheral.IComputerAccess;
 import de.srendi.advancedperipherals.common.addons.APAddon;
@@ -158,6 +159,15 @@ public class RSBridgePeripheral extends AbstractStorageSystemPeripheral<StorageS
     @Override
     public List<?> getDrivesImpl() {
         return RSApi.listDrives(getNetwork());
+    }
+
+    // RS-only, not on IStorageSystemPeripheral: the ME Bridge has no equivalent.
+    @LuaFunction(mainThread = true)
+    public final MethodResult getCrafters() {
+        if (!isAvailable()) {
+            return NOT_CONNECTED_RESULT;
+        }
+        return MethodResult.of(RSApi.getCrafters(getNetwork(), getLevel()));
     }
 
     @Override

--- a/src/main/java/de/srendi/advancedperipherals/common/addons/refinedstorage/RSApi.java
+++ b/src/main/java/de/srendi/advancedperipherals/common/addons/refinedstorage/RSApi.java
@@ -17,6 +17,8 @@ import com.refinedmods.refinedstorage.api.resource.ResourceKey;
 import com.refinedmods.refinedstorage.api.storage.StateTrackedStorage;
 import com.refinedmods.refinedstorage.api.storage.Storage;
 import com.refinedmods.refinedstorage.api.storage.composite.CompositeStorage;
+import com.refinedmods.refinedstorage.common.api.RefinedStorageApi;
+import com.refinedmods.refinedstorage.common.api.autocrafting.Autocrafter;
 import com.refinedmods.refinedstorage.common.api.storage.SerializableStorage;
 import com.refinedmods.refinedstorage.common.api.support.network.InWorldNetworkNodeContainer;
 import com.refinedmods.refinedstorage.common.api.support.resource.PlatformResourceKey;
@@ -39,6 +41,7 @@ import de.srendi.advancedperipherals.common.util.inventory.FluidUtil;
 import de.srendi.advancedperipherals.common.util.inventory.GenericFilter;
 import de.srendi.advancedperipherals.common.util.inventory.ItemFilter;
 import de.srendi.advancedperipherals.common.util.inventory.ItemUtil;
+import net.minecraft.world.Container;
 import net.minecraft.world.item.ItemStack;
 import net.neoforged.neoforge.capabilities.RegisterCapabilitiesEvent;
 import net.neoforged.neoforge.fluids.FluidStack;
@@ -286,6 +289,34 @@ public class RSApi {
             }
         }
         return drives;
+    }
+
+    public static List<Object> getCrafters(Network network, net.minecraft.world.level.Level level) {
+        List<Object> crafters = new ArrayList<>();
+
+        GraphNetworkComponent graphNetworkComponent = network.getComponent(GraphNetworkComponent.class);
+        AutocraftingNetworkComponent autocrafting = network.getComponent(AutocraftingNetworkComponent.class);
+
+        for (Autocrafter autocrafter : graphNetworkComponent.getContainers(Autocrafter.class)) {
+            Map<String, Object> properties = new HashMap<>();
+            properties.put("name", autocrafter.getAutocrafterName().getString());
+            properties.put("position", LuaConverter.posToLua(autocrafter.getLocalPosition()));
+            properties.put("visible", autocrafter.isVisibleToTheAutocrafterManager());
+
+            List<Object> patterns = new ArrayList<>();
+            Container container = autocrafter.getPatternContainer();
+            for (int i = 0; i < container.getContainerSize(); i++) {
+                ItemStack stack = container.getItem(i);
+                if (stack.isEmpty())
+                    continue;
+                Pattern pattern = RefinedStorageApi.INSTANCE.getPattern(stack, level).orElse(null);
+                if (pattern != null)
+                    patterns.add(parsePattern(pattern, autocrafting));
+            }
+            properties.put("patterns", patterns);
+            crafters.add(properties);
+        }
+        return crafters;
     }
 
     /**

--- a/src/main/java/de/srendi/advancedperipherals/common/smartglasses/modules/overlay/propertytypes/StringProperty.java
+++ b/src/main/java/de/srendi/advancedperipherals/common/smartglasses/modules/overlay/propertytypes/StringProperty.java
@@ -11,5 +11,5 @@ import java.lang.annotation.Target;
 @Target(ElementType.FIELD)
 @ObjectProperty(StringType.class)
 public @interface StringProperty {
-	boolean utf8() default false;
+    boolean utf8() default false;
 }


### PR DESCRIPTION
Lists every autocrafter on the **refined storage** network with its name, position, visibility and the patterns it holds. For RS-only; not added to the shared IStorageSystemPeripheral interface.

**PLEASE READ THE [GUIDELINES](https://github.com/IntelligenceModding/AdvancedPeripherals/blob/dev/1.21.1/CONTRIBUTING.md) BEFORE MAKING A CONTRIBUTION**


* **Please check if the PR fulfills these requirements**
- [x] The commit message are well described
- [ ] Docs have been added / updated (for features or maybe bugs which were noted). If not, please update the needed documentation [here](https://github.com/IntelligenceModding/Advanced-Peripherals-Documentation/pulls). Feel free to remove this check if you don't need it
- [x] All changes have fully been tested

* **What kind of change does this PR introduce?** (Bug fix, feature, ...)

New feature for RS-Bridge to get autocrafters and list their patterns.

* **What is the current behavior?** (You can also link to an open issue here)

No such feature exists today

* **What is the new behavior (if this is a feature change)?**

Makes it possible to list autocrafters from Refined Storage so you can get inventory for all or specific autocrafter from RS.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their scripts due to this PR?)

NO.

* **Other information**:

Tested on 1.21.1